### PR TITLE
Speed up staged writes and add batched ledger updates

### DIFF
--- a/lisp/interface.scm
+++ b/lisp/interface.scm
@@ -242,7 +242,7 @@
                       ((bridge!) (~authenticate) (apply bridge! keyword-args))
                       ((bridge-synchronize!) (~authenticate) (apply bridge-synchronize! keyword-args))
                       ((*step!*) (~authenticate) (apply *step!* keyword-args))
-                      ((set! unpin!) (~authenticate) (~method))
+                      ((set! set-batch! unpin!) (~authenticate) (~method))
                       ((size synchronize info config get) (~method))
                       (else (error 'api-error "Interface does not implement API endpoint")))))
            ((root 'set!) '(control object ledger) (ledger))

--- a/lisp/ledger.scm
+++ b/lisp/ledger.scm
@@ -65,9 +65,19 @@
     ;;   Returns:
     ;;     boolean: #t after staging.
     ((self '~path-check) path #t #t)
-    (let ((standard (sync-eval ((self '~field!) 'standard) #f))
-          (stage ((self '~field!) 'stage)))
-      ((self '~field!) 'stage ((standard 'deep-set!) stage path value))))
+    (if (> (length path) 2)
+        (let ((standard (sync-eval ((self '~field!) 'standard) #f))
+              (stage ((self '~field!) 'stage)))
+          ((self '~field!) 'stage ((standard 'deep-set!) stage path value)))
+        (let ((stage-obj (sync-eval ((self '~field!) 'stage) #f)))
+          ((stage-obj 'set!) (car path) value)
+          ((self '~field!) 'stage (stage-obj)))))
+
+  (define-method (set-batch! self paths values)
+    (map (lambda (path) ((self '~path-check) path #t #t)) paths)
+    (let ((stage-obj (sync-eval ((self '~field!) 'stage) #f)))
+      ((stage-obj 'set-batch!) (map car paths) values)
+      ((self '~field!) 'stage (stage-obj))))
 
   (define-method (resolve self path pinned? proof? head)
     ;; Get value at path, optionally with proof details.

--- a/lisp/tree.scm
+++ b/lisp/tree.scm
@@ -350,6 +350,9 @@
                                      (else `(*tree* expr ,value)))))
                   ((self '~r-write!) (map (self '~key->bytes) path) ((self 'obj->node) content))))))
 
+  (define-method (set-batch! self paths values)
+    (map (lambda (path value) ((self 'set!) path value)) paths values) #t)
+
   (define-method (copy! self source path)
     ;; Copy raw node from source path to target path.
     ;;   Args:

--- a/tests/test-interface.scm
+++ b/tests/test-interface.scm
@@ -83,6 +83,17 @@
   (let ((query '((function get) (arguments ((path ((*state* hello))))))))
     (assert (interface-query journal-1 interface-1 query) "world"))
 
+  (let ((query '((function set-batch!)
+                 (arguments ((paths (((*state* batch alpha)) ((*state* batch beta))))
+                             (values ("a" "b")))))))
+    (assert (interface-query journal-1 interface-1 query) #t))
+
+  (let ((query '((function get) (arguments ((path ((*state* batch alpha))))))))
+    (assert (interface-query journal-1 interface-1 query) "a"))
+
+  (let ((query '((function get) (arguments ((path ((*state* batch beta))))))))
+    (assert (interface-query journal-1 interface-1 query) "b"))
+
   (let ((query '((function *step!*))))
     (assert (interface-query journal-1 interface-1 query) 1))
 

--- a/tests/test-ledger.scm
+++ b/tests/test-ledger.scm
@@ -129,8 +129,14 @@
   (assert ((ledger-1 'set!) '((*state* do pin this)) "yes") #t)
   (assert ((ledger-1 'set!) '((*state* do pin that)) "yes") #t)
   (assert ((ledger-1 'set!) '((*state* do not pin)) "no") #t)
+  (assert ((ledger-1 'set-batch!)
+           '(((*state* batch alpha))
+             ((*state* batch beta)))
+           '("a" "b")) #t)
   (assert ((ledger-1 'get) '((*state* do not pin))) "no")
   (assert ((ledger-1 'get) '((*state* do pin))) '(directory ((this value) (that value)) #t))
+  (assert ((ledger-1 'get) '((*state* batch alpha))) "a")
+  (assert ((ledger-1 'get) '((*state* batch beta))) "b")
 
   (assert (step-all! ledger-1) '(2))
 


### PR DESCRIPTION
- fast-path shallow ledger set! updates through the staged tree object to trim per-write overhead
- add set-batch! support in tree and ledger and expose it through the interface
- add direct ledger and interface tests covering batched staged writes