### PR TITLE
Move bridge synchronization into the control step pipeline

### DIFF
--- a/lisp/control.scm
+++ b/lisp/control.scm
@@ -22,10 +22,10 @@
            (authenticate secret)
            (eval expression))
 
-         (define (control-step secret)
+         (define* (control-step secret (query ()))
            (authenticate secret)
            (let* ((step-handler (eval (byte-vector->expression (sync-car node-10)))))
-             (update! (step-handler root secret))))
+             (update! (step-handler root secret query))))
 
          (define (control-call secret function)
            (authenticate secret)
@@ -207,21 +207,8 @@
               (else (error 'unimplemented-method "Basic record does not implement method")))))))
 
   (define step
-    '(lambda (root secret)
-       (let* ((less? (lambda (x y)
-                       (cond ((and (number? x) (number? y)) (< x y))
-                             ((and (number? x) (not (number? y))) #t)
-                             ((and (not (number? x)) (number? y)) #f)
-                             (else (string<=? (symbol->string x) (symbol->string y))))))
-              (names ((root 'get) '(control step))))
-         (let loop ((names (sort! names less?)) (rets '()))
-           (if (null? names) (reverse rets)
-               (let ((ret (sync-call `(*call* ,secret
-                                              (lambda (root)
-                                                (let* ((path '(control step ,(car names)))
-                                                       (expr ((root 'get) path)))
-                                                  ((eval expr) root)))) #t)))
-                 (loop (cdr names) (cons `(,(car names) ,ret) rets))))))))
+    '(lambda (root secret query)
+       "No operation set for step"))
 
   (define query
     '(lambda (root query)

--- a/lisp/interface.scm
+++ b/lisp/interface.scm
@@ -14,6 +14,9 @@
   (define (set-query function)
     (sync-call `(*set-query* ,secret-1 ,function) #t))
 
+  (define (set-step function)
+    (sync-call `(*set-step* ,secret-1 ,function) #t))
+
   ;; install and instantiate standard library
   (call `(lambda (root)
            (let ((init (caddr ,standard)))
@@ -198,36 +201,6 @@
                       (args `((name ,name) (interface ,interface) (info ,info))))
                  (~self-call 'bridge! args #t))))
 
-         (define* (bridge-synchronize! (name (error 'arg-error "Missing arg: name")) index response)
-           ;; Synchronize a bridge, optionally using a provided remote response.
-           ;;   Args:
-           ;;     name (symbol): bridge name.
-           ;;     index (integer): optional last synchronized index.
-           ;;     response (expression): optional serialized sync response.
-           ;;   Returns:
-           ;;     boolean: #t after synchronization.
-           (if (and index response) ((ledger 'bridge-synchronize!) name index response)
-               (let* ((last ((ledger 'get) `((*bridge* ,name chain))))
-                      (index (if (sync-node? last) (- (((sync-eval last #f) 'size)) 1) -1))
-                      (interface ((ledger 'config) `(private bridge ,name interface)))
-                      (response (sync-remote interface `((function synchronize) (arguments ((index ,index))))))
-                      (args `((name ,name) (index ,index) (response ,response))))
-                 (~self-call 'bridge-synchronize! args #t))))
-
-         (define* (*step!* mutate?)
-           ;; Run one interface step, optionally mutating the local ledger at the end.
-           ;;   Args:
-           ;;     mutate? (boolean): #t to perform the final local step.
-           ;;   Returns:
-           ;;     integer: resulting ledger size.
-           (if mutate? (begin ((ledger 'step!) (system-time-unix)) ((ledger 'size)))
-               (let loop ((names (map car ((ledger 'config) '(private bridge)))))
-                 (if (null? names)
-                     (~self-call '*step!* '((mutate? #t)) #t)
-                     (begin
-                       (~self-call 'bridge-synchronize! `((name ,(car names))) #f)
-                       (loop (cdr names)))))))
-
          (define (~method)
            (let ((result (apply (ledger (cadr func)) keyword-args)))
              result))
@@ -240,8 +213,6 @@
                       ((trace) (apply trace keyword-args))
                       ((pin!) (~authenticate) (apply pin! keyword-args))
                       ((bridge!) (~authenticate) (apply bridge! keyword-args))
-                      ((bridge-synchronize!) (~authenticate) (apply bridge-synchronize! keyword-args))
-                      ((*step!*) (~authenticate) (apply *step!* keyword-args))
                       ((set! set-batch! unpin!) (~authenticate) (~method))
                       ((size synchronize info config get) (~method))
                       (else (error 'api-error "Interface does not implement API endpoint")))))
@@ -257,5 +228,59 @@
                 (if (null? queries) (reverse result)
                     (let ((subquery (if auth (append (car queries) auth) (car queries)))) 
                       (loop (cdr queries) (cons (query-once subquery) result))))))))))
+  (define step-once
+    '(lambda (root secret query)
+       (let* ((query (if (null? query) '(ledger-step) query))
+              (std-node ((root 'get) '(control object standard)))
+              (standard (sync-eval std-node #f))
+              (node ((root 'get) '(control object ledger)))
+              (ledger (sync-eval node #f)))
+
+         ;; --- query helpers ---
+
+         (define (~self-call blocking? query)
+           (sync-call `(*step* ,secret ,query) blocking?))
+
+         ;; --- handlers ---
+
+         (define* (bridge-synchronize! (name (error 'arg-error "Missing arg: name")) index response)
+           ;; Synchronize a bridge, optionally using a provided remote response.
+           ;;   Args:
+           ;;     name (symbol): bridge name.
+           ;;     index (integer): optional last synchronized index.
+           ;;     response (expression): optional serialized sync response.
+           ;;   Returns:
+           ;;     boolean: #t after synchronization.
+           (if (and index response) ((ledger 'bridge-synchronize!) name index response)
+               (let* ((last ((ledger 'get) `((*bridge* ,name chain))))
+                      (index (if (sync-node? last) (- (((sync-eval last #f) 'size)) 1) -1))
+                      (interface ((ledger 'config) `(private bridge ,name interface)))
+                      (response (sync-remote interface `((function synchronize) (arguments ((index ,index)))))))
+                 (~self-call #t `(bridge-synchronize! ,name ,index ,response)))))
+
+         (define* (ledger-step mutate?)
+           ;; Run one interface step, optionally mutating the local ledger at the end.
+           ;;   Args:
+           ;;     mutate? (boolean): #t to perform the final local step.
+           ;;   Returns:
+           ;;     integer: resulting ledger size.
+           (if mutate? (begin ((ledger 'step!) (system-time-unix)) ((ledger 'size)))
+               (let loop ((names (map car ((ledger 'config) '(private bridge)))))
+                 (if (null? names)
+                     (~self-call #t '(ledger-step #t))
+                     (begin
+                       (~self-call #f `(bridge-synchronize! ,(car names)))
+                       (loop (cdr names)))))))
+
+         ;; --- dispatch ---
+
+         (let ((ret (case (car query)
+                      ((ledger-step) (apply ledger-step (cdr query)))
+                      ((bridge-synchronize!) (apply bridge-synchronize! (cdr query)))
+                      (else (error 'api-error "Step does not implement operation")))))
+           ((root 'set!) '(control object ledger) (ledger))
+           ret))))
+
+  (set-step step-once)
 
   "Installed interface")

--- a/tests/test-interface.scm
+++ b/tests/test-interface.scm
@@ -51,6 +51,9 @@
   (define (interface-query journal interface query)
     (journal-query journal (append query `((authentication ,interface)))))
 
+  (define (admin-step journal secret)
+    (journal-query journal `(*step* ,secret)))
+
   (define interface-1 "http://journal-1.test/interface")
   (define interface-2 "http://journal-2.test/interface")
   (define interface-3 "http://journal-3.test/interface")
@@ -94,8 +97,7 @@
   (let ((query '((function get) (arguments ((path ((*state* batch beta))))))))
     (assert (interface-query journal-1 interface-1 query) "b"))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 1))
+  (assert (admin-step journal-1 "pass-1") 1)
 
   (let ((query '((function resolve) (arguments ((path (-1 (*state* hello))) (pinned? #f) (proof? #f))))))
     (assert (interface-query journal-1 interface-1 query) "world"))
@@ -109,8 +111,7 @@
   (let ((query '((function set!) (arguments ((path ((*state* do not pin))) (value "no"))))))
     (assert (interface-query journal-1 interface-1 query) #t))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 2))
+  (assert (admin-step journal-1 "pass-1") 2)
 
   (let ((query '((function pin!) (arguments ((path (1 (*state* do pin this))))))))
     (assert (interface-query journal-1 interface-1 query) #t))
@@ -124,11 +125,9 @@
   (let ((query '((function set!) (arguments ((path ((*state* a b c))) (value 42))))))
     (assert (interface-query journal-2 interface-2 query) #t))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-2 interface-2 query) 1))
+  (assert (admin-step journal-2 "pass-2") 1)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 3))
+  (assert (admin-step journal-1 "pass-1") 3)
 
   (let* ((path '(-1 (*bridge* journal-2 chain) -1 (*state* a b c)))
          (query `((function resolve) (arguments ((path ,path) (pinned? #f) (proof? #f))))))
@@ -159,43 +158,33 @@
   (let ((query '((function set!) (arguments ((path ((*state* g h i))) (value "world"))))))
     (assert (interface-query journal-5 interface-5 query) #t))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-3 interface-3 query) 1))
+  (assert (admin-step journal-3 "pass-3") 1)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-4 interface-4 query) 1))
+  (assert (admin-step journal-4 "pass-4") 1)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-5 interface-5 query) 1))
+  (assert (admin-step journal-5 "pass-5") 1)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-3 interface-3 query) 2))
+  (assert (admin-step journal-3 "pass-3") 2)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-2 interface-2 query) 2))
+  (assert (admin-step journal-2 "pass-2") 2)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 4))
+  (assert (admin-step journal-1 "pass-1") 4)
 
   (let* ((path '(-1 (*bridge* journal-3 chain) -1 (*state* d e f)))
          (query `((function resolve) (arguments ((path ,path) (pinned? #f) (proof? #f))))))
     (assert (interface-query journal-2 interface-2 query) 64))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-2 interface-2 query) 2))
+  (assert (admin-step journal-2 "pass-2") 2)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 4))
+  (assert (admin-step journal-1 "pass-1") 4)
 
   (let* ((path '(-1 (*bridge* journal-2 chain) -1 (*bridge* journal-3 chain) -1 (*state* d e f)))
          (query `((function resolve) (arguments ((path ,path) (pinned? #f) (proof? #f))))))
     (assert (interface-query journal-1 interface-1 query) 64))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-2 interface-2 query) 2))
+  (assert (admin-step journal-2 "pass-2") 2)
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 4))
+  (assert (admin-step journal-1 "pass-1") 4)
 
   (let* ((path '(-1 (*bridge* journal-2 chain) -1 (*bridge* journal-3 chain) -1 (*bridge* journal-4 chain) -1 (*state* g h i)))
          (query `((function resolve) (arguments ((path ,path) (pinned? #f) (proof? #f))))))
@@ -208,26 +197,22 @@
   (let ((query '((function set!) (arguments ((path ((*state* tick))) (value 0))))))
     (assert (interface-query journal-1 interface-1 query) #t))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 5))
+  (assert (admin-step journal-1 "pass-1") 5)
 
   (let ((query '((function set!) (arguments ((path ((*state* tick))) (value 1))))))
     (assert (interface-query journal-1 interface-1 query) #t))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 6))
+  (assert (admin-step journal-1 "pass-1") 6)
 
   (let ((query '((function set!) (arguments ((path ((*state* tick))) (value 2))))))
     (assert (interface-query journal-1 interface-1 query) #t))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 7))
+  (assert (admin-step journal-1 "pass-1") 7)
 
   (let ((query '((function set!) (arguments ((path ((*state* tick))) (value 3))))))
     (assert (interface-query journal-1 interface-1 query) #t))
 
-  (let ((query '((function *step!*))))
-    (assert (interface-query journal-1 interface-1 query) 8))
+  (assert (admin-step journal-1 "pass-1") 8)
 
   (let ((query '((function resolve) (arguments ((path (1 (*state* do pin))) (pinned? #f) (proof? #f))))))
     (assert (interface-query journal-1 interface-1 query) '(directory ((this value) (that value)) #t)))


### PR DESCRIPTION
- make control *step* accept an optional query payload and dispatch through an installed step handler
- move bridge synchronization and final ledger stepping out of the public interface query path
- update interface tests to drive stepping through the admin control surface instead of the old *step!* endpoint